### PR TITLE
feat: Add command configuration option for Bitcoin chart

### DIFF
--- a/charts/bitcoin/Chart.yaml
+++ b/charts/bitcoin/Chart.yaml
@@ -5,7 +5,7 @@ keywords:
   - bitcoin
   - knots
 type: application
-version: 1.0.8
+version: 1.0.9
 home: "https://github.com/cosmicrocks/helm-charts/tree/main/charts/bitcoin"
 sources:
   - "https://github.com/cosmicrocks/helm-charts/tree/main/charts/bitcoin"

--- a/charts/bitcoin/README.md
+++ b/charts/bitcoin/README.md
@@ -60,6 +60,7 @@ A Helm chart for Bitcoin knots with datum for decentralized mining by the OCEAN 
 | bitcoin.zmqPubHashBlock | string | `"tcp://0.0.0.0:8433"` |  |
 | bitcoin.zmqPubRawBlock | string | `"tcp://0.0.0.0:8432"` |  |
 | bitcoin.zmqPubRawTx | string | `"tcp://0.0.0.0:8431"` |  |
+| command | list | `[]` |  |
 | datum.api.adminPassword | string | `"admin"` |  |
 | datum.api.extraBlockSubmissionsUrls | string | `"[]"` |  |
 | datum.bitcoin.rpcHost | string | `"localhost:8332"` |  |

--- a/charts/bitcoin/README.md
+++ b/charts/bitcoin/README.md
@@ -1,6 +1,6 @@
 # bitcoin
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: knots20250305](https://img.shields.io/badge/AppVersion-knots20250305-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: knots20250305](https://img.shields.io/badge/AppVersion-knots20250305-informational?style=flat-square)
 
 A Helm chart for Bitcoin knots with datum for decentralized mining by the OCEAN protocol.
 

--- a/charts/bitcoin/templates/deployment.yaml
+++ b/charts/bitcoin/templates/deployment.yaml
@@ -54,6 +54,7 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "bitcoin-cli stop"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [{{ .Values.command | default []  }}]
           env:
             # Core Settings
             - name: SERVER_ENABLED

--- a/charts/bitcoin/templates/deployment.yaml
+++ b/charts/bitcoin/templates/deployment.yaml
@@ -54,7 +54,10 @@ spec:
               exec:
                 command: ["/bin/sh", "-c", "bitcoin-cli stop"]
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: [{{ .Values.command | default []  }}]
+          {{- if .Values.command }}
+          command:
+            {{- toYaml .Values.command | nindent 12 }}
+          {{- end }}
           env:
             # Core Settings
             - name: SERVER_ENABLED

--- a/charts/bitcoin/values.yaml
+++ b/charts/bitcoin/values.yaml
@@ -7,6 +7,8 @@ global:
 secrets:
   create: true
 
+command: []
+
 bitcoin:
   # Core Settings
   serverEnabled: 1


### PR DESCRIPTION
This pull request introduces a new `command` parameter to the Bitcoin Helm chart, allowing users to specify custom commands for the container. The changes span across documentation, template files, and configuration values to ensure the feature is fully integrated.

### Addition of `command` parameter:

* **Documentation Update**:
  - Added the `command` parameter to the `README.md` file under the configuration options, with a default value of an empty list. (`charts/bitcoin/README.md`)

* **Template Update**:
  - Updated the `deployment.yaml` template to include the `command` parameter, which defaults to an empty list if not specified. (`charts/bitcoin/templates/deployment.yaml`)

* **Default Configuration**:
  - Added the `command` parameter to the `values.yaml` file with a default value of an empty list. (`charts/bitcoin/values.yaml`)- Introduced a new `command` list option in `values.yaml` to allow customization of the command executed in the Bitcoin deployment.
- Updated `deployment.yaml` to utilize the new `command` configuration, enhancing flexibility in deployment settings.
- Documented the new `command` option in `README.md` for user clarity.